### PR TITLE
Cast slug increment to determine max value for the slug generation.

### DIFF
--- a/src/Repository/ContainerRepository.php
+++ b/src/Repository/ContainerRepository.php
@@ -186,7 +186,7 @@ class ContainerRepository
         $exactWrap = sprintf('^%s$', $slug);
         $incrementWrap = sprintf('^%s-[0-9]+$', $slug);
         $stmt = $this->db->executeQuery(
-            'select max(substring(slug from ?)) as increment from containers where slug regexp ? or slug regexp ?',
+            'select max(cast(substring(slug from ?) as unsigned)) as increment from containers where slug regexp ? or slug regexp ?',
             [$incrementPosition, $exactWrap, $incrementWrap],
             [\PDO::PARAM_INT]
         );

--- a/tests/Fixture/MainFixture.php
+++ b/tests/Fixture/MainFixture.php
@@ -32,6 +32,16 @@ class MainFixture implements FixtureInterface
                     'container_item_count' => 1,
                     'created' => '2014-01-01 00:00:00',
                     'modified' => '2014-01-01 00:00:00'
+                ],
+                [
+                    'id' => 1000,
+                    'user_id' => 1,
+                    'uuid' => 'deprecated',
+                    'name' => 'Box 10',
+                    'slug' => 'box-10',
+                    'container_item_count' => 0,
+                    'created' => '2015-01-01 00:00:00',
+                    'modified' => '2015-01-01 00:00:00'
                 ]
             ],
             'container_items' => [

--- a/tests/Repository/ContainerRepositoryTest.php
+++ b/tests/Repository/ContainerRepositoryTest.php
@@ -26,7 +26,7 @@ class ContainerRepositoryTest extends \Boxmeup\Test\DatabaseTestCase
     public function testGetTotalContainersByUser()
     {
         $result = $this->repo->getTotalContainersByUser($this->user->byId(1));
-        $this->assertEquals(1, $result);
+        $this->assertEquals(2, $result);
     }
 
     public function testCreate()
@@ -62,6 +62,17 @@ class ContainerRepositoryTest extends \Boxmeup\Test\DatabaseTestCase
         $this->repo->save($container);
         $this->assertNotEmpty($container['id']);
         $this->assertEquals('test-create-1-1', $container['slug']);
+    }
+
+    public function testIntegerCastOfUniqueSlugCreation()
+    {
+        $container = new Container([
+            'user' => $this->user->byId(1),
+            'name' => 'Box',
+            'slug' => 'box'
+        ]);
+        $this->repo->save($container);
+        $this->assertEquals('box-11', $container['slug']);
     }
 
     /**


### PR DESCRIPTION
Containers were not getting the real max value to append to the slug (due to the fact that it was comparing strings which are not arithmetic with their "max" value).